### PR TITLE
Rails 3.2 and RefineryCMS 2.1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,8 @@ end
 
 # Refinery/rails should pull in the proper versions of these
 group :assets do
-  gem 'sass-rails'
-  gem 'coffee-rails'
+  gem 'sass-rails', '3.2.4'
+  gem 'coffee-rails', '3.2.2'
   gem 'uglifier'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem 'refinerycms'
 gem 'refinerycms-i18n'
+gem 'rails', '~> 3.2.13'
 
 group :development, :test do
   gem 'refinerycms-testing'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem 'refinerycms-testing'
   gem 'guard-rspec', '~> 0.6.0'
   gem "capybara-email", "~> 0.1.2"
+  gem 'babosa','~> 0.3.11'
 
   platforms :jruby do
     gem 'activerecord-jdbcsqlite3-adapter'


### PR DESCRIPTION
Hey Chris, after a few false starts, I have the Gemfile updated to Rails 3.2.13 and the tests passing for Ruby 1.9.3, Ruby 2.0.0, and jruby-19mode. This uses the current stable version of RefineryCMS, 2.1.5.

I think I should start a new branch, refinery3, for the rest of the changes since they will not be compatible with the current stable version. What do you think?

![screenshot from 2015-07-30 15 37 58](https://cloud.githubusercontent.com/assets/102356/8993138/005aeb5c-36d1-11e5-9fcd-fa519e212bc1.png)
